### PR TITLE
feat: split extension steps

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,18 +1,37 @@
-# ECMAScript proposal: Object.clone()
+# Object.clone()
 
-Stage 0 - Strawperson
+## Status
 
-With the spread operator `...`, it is fairly simple to make a shallow clone of an object.
+Champion(s): TBD
+Author: Alex Lohr
+Stage: 0 - Strawperson
 
-However, in some cases you need to create a clone of all layers inside the object. It would be much more efficient to natively copy the referenced memory than to clone it manually.
+## Motivation
+
+With the spread operator `...`, it is simple to make a shallow clone of an object. In some cases, the requirement arises to create a deep clone of the object. It would be much more efficient to natively copy the referenced memory than to clone it manually. A native method would also help circumvent the issues of a naive implementation.
 
 ## Call for feedback
 
-As long as there is no TC39 member who will champion this proposal, this is open for feedback, questions and improvements. Use [Issues](https://github.com/atk/object-clone-proposal/issues) and [PRs](https://github.com/atk/object-clone-proposal/pulls) as you see fit.
+As long as there is no TC39 member who will champion this proposal, this is completely open for feedback, questions and improvements. Use [Issues](https://github.com/atk/object-clone-proposal/issues) and [PRs](https://github.com/atk/object-clone-proposal/pulls) as you see fit.
+
+## Use cases
+
+- convenient way of forcing complete rerender for MVC framworks like react
+- creating immutable clones of state for an undo history
 
 ## Syntax
 
-    const clone = Object.clone(object)
+```javascript
+const clone = Object.clone(object);
+const extendedClone = Object.clone(
+  object,
+  new Map([[MyConstructor, (instance, map) => {
+    const clone = instance.clone();
+    map.set(instance, clone);
+    return clone;
+  }]])
+);
+```
 
 ## Prior art
 
@@ -34,9 +53,9 @@ Most other languages that handle references have similar functionality, i.e.
 
 Cloning an object has been a moving target for a while. With all the new additions to the language like TypedArray, (Weak)Map, Symbol, the requirements have changed fast. While this means any polyfill might have to be updated frequently, it also means a native implementation will be quite beneficial.
 
-### What will be cloned?
+### What will be cloned by default?
 
-`Object.clone` will not clone literals that will be reinstantiated if their value changed and thus need not be cloned, like `undefined, null, boolean, number, string, function` as well as values that cannot be cloned for they would cease to work as clones like `Symbol` or have a lack of introspection like `WeakMap`; those will be merely returned. The same principle applies to nested properties of these types. Everything else will be cloned recursively.
+`Object.clone` will by default not clone literals that will be reinstantiated if their value changed and thus need not be cloned, like `undefined, null, boolean, number, string, function` as well as values that cannot be cloned for they would cease to work as clones like `Symbol` or have a lack of introspection like `WeakMap` or will usually be handled as unique reference like `Node`; those will be merely returned. The same principle applies to nested properties of these types. Everything else will be cloned recursively.
 
 `function` here is a bit of an exception, since it can have properties that can be changed:
 
@@ -52,9 +71,48 @@ console.log(f.property) // false
 
 A singleton will be the preferred pattern for such a use case and since it is not a function but an instance, this would be cloned. The same behavior is also apparent in all tested libraries counted as prior art; if well documented, it should not cause issues.
 
-### Cyclical references
+### How to extend what is cloned?
 
-Another edge case for cloning objects are cyclical references, which can easily lead to uncaught range errors. If unhandled, the result would look like this:
+`Object.clone` supports an optional second argument, which should contain a `Map([[constructor, cloneMethod]])`, allowing to extend the types that are cloned manually. CloneMethod here is a function that has the following blueprint:
+
+```javascript
+const cloneMethod = (object, map, clone) => {
+  // create a reference (without cloned data)
+  const reference = object.cloneRef();
+  // store reference in the map
+  map.set(object, reference);
+  // fill reference with cloned data.
+  // Use clone here instead of Object.clone
+  object.keys().forEach((key) => {
+    reference[key] = clone(object[key]);
+  });
+  return reference;
+}
+```
+
+For example, if you want to clone DOM Nodes and functions, you can extend `Object.clone` like this:
+
+```javascript
+const clone = Object.clone(object, new Map([
+  [Function, (func, map, clone) => {
+    const ref = new Function(`return ${func.toString()}`)();
+    map.set(func, ref);
+    for (key in func) {
+      ref[key] = clone(func[key])
+    }
+    return ref
+  }],
+  [Node, (node, map) => {
+    const ref = node.cloneNode(true);
+    map.set(node, ref);
+    return ref;
+  }]
+]));
+```
+
+### Cyclic references
+
+Another edge case for cloning objects are cyclic references, which can easily lead to uncaught range errors. If unhandled, the result would look like this:
 
 ```javascript
 const x = []
@@ -77,11 +135,22 @@ It may be possible to abuse this method in order to spam the garbage collector a
 
 ```javascript
 if (typeof Object.clone !== "function") {
-  const clone = (obj, map) => {
-    if (obj === null || typeof obj !== "object" || obj instanceof WeakMap)
+  const unclonable = /^\[object (?:Undefined|Null|Boolean|Number|String|Symbol|WeakMap)\]$/;
+  const clone = (obj, map, methodMap) => {
+    if (
+      unclonable.test(Object.prototype.toString.call(obj)) ||
+      (typeof obj !== "object" && !methodMap.has(obj.constructor))
+    ) {
       return obj;
+    }
 
     if (map.has(obj)) return map.get(obj);
+
+    if (methodMap.has(obj.constructor)) {
+      return methodMap.get(obj.constructor)(obj, map, (obj) =>
+        clone(obj, map, methodMap)
+      );
+    }
 
     const temp =
       obj instanceof TypedArray
@@ -91,20 +160,21 @@ if (typeof Object.clone !== "function") {
     map.set(obj, temp);
 
     if (obj instanceof TypedArray) {
-      temp.set(obj.map((value) => clone(value, map)));
+      temp.set(obj.map((value) => clone(value, map, methodMap)));
     } else if (obj instanceof Map) {
-      obj.forEach((value, key) => temp.set(key, clone(value, map)));
+      obj.forEach((value, key) => temp.set(key, clone(value, map, methodMap)));
     } else if (obj instanceof Date) {
       temp.setTime(obj.getTime());
     } else {
       for (const key in obj) {
         if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          temp[key] = clone(obj[key], map);
+          temp[key] = clone(obj[key], map, methodMap);
         }
       }
     }
     return temp;
   };
-  Object.clone = (obj) => clone(obj, new Map());
+  Object.clone = (obj, methodMap) =>
+    clone(obj, new Map(), methodMap || new Map());
 }
 ```

--- a/object-clone-tests.mjs
+++ b/object-clone-tests.mjs
@@ -101,6 +101,55 @@ const testObjectClone = () => {
     }
   }
   testClones(new Test(), "test class");
+
+  const testExtension = (value, methodMap, name, additionalTests) => {
+    const clone = Object.clone(value, methodMap);
+    strict.notStrictEqual(clone, value, `${name} was not cloned`);
+    if (additionalTests) {
+      additionalTests(clone, value, name);
+    }
+  };
+
+  console.log("  clones functions if so extended");
+  function testFunc() {
+    return "test";
+  }
+  testFunc.property = "test";
+  testFunc.testObject = { a: [1, 2, 3] };
+  testExtension(
+    testFunc,
+    new Map([
+      [
+        Function,
+        (func, map, clone) => {
+          const ref = new Function(`return ${func.toString()}`)();
+          map.set(func, ref);
+          for (const key in func) {
+            ref[key] = clone(func[key]);
+          }
+          return ref;
+        },
+      ],
+    ]),
+    "function (by extension)",
+    (clone, value, name) => {
+      strict.strictEqual(
+        clone.property,
+        value.property,
+        `property of ${name} could not be cloned`
+      );
+      strict.notStrictEqual(
+        clone.testObject,
+        value.testObject,
+        `object property of ${name} was not cloned`
+      );
+      strict.deepStrictEqual(
+        clone.testObject,
+        value.testObject,
+        `object property of ${name} could not be cloned`
+      );
+    }
+  );
 };
 
 testObjectClone();

--- a/object-clone-tests.mjs
+++ b/object-clone-tests.mjs
@@ -119,20 +119,15 @@ const testObjectClone = () => {
   testExtension(
     testFunc,
     new Map([
-      [
-        Function,
-        (func, map, clone) => {
-          const ref = new Function(`return ${func.toString()}`)();
-          map.set(func, ref);
-          for (const key in func) {
-            ref[key] = clone(func[key]);
-          }
-          return ref;
-        },
-      ],
+      [Function, [(func) => new Function(`return ${func.toString()}`)()]],
     ]),
     "function (by extension)",
     (clone, value, name) => {
+      strict.strictEqual(
+        clone(),
+        value(),
+        "functionality of clone of ${name} fails"
+      );
       strict.strictEqual(
         clone.property,
         value.property,

--- a/object-clone.js
+++ b/object-clone.js
@@ -1,42 +1,64 @@
 if (typeof Object.clone !== "function") {
   const unclonable = /^\[object (?:Undefined|Null|Boolean|Number|String|Symbol|WeakMap)\]$/;
-  const clone = (obj, map, methodMap) => {
-    if (
-      unclonable.test(Object.prototype.toString.call(obj)) ||
-      (typeof obj !== "object" && !methodMap.has(obj.constructor))
-    ) {
-      return obj;
-    }
 
-    if (map.has(obj)) return map.get(obj);
+  const defaultCreateReference = (obj) =>
+    obj instanceof TypedArray
+      ? new obj.constructor(obj.length)
+      : new obj.constructor();
 
-    if (methodMap.has(obj.constructor)) {
-      return methodMap.get(obj.constructor)(obj, map, (obj) =>
-        clone(obj, map, methodMap)
-      );
-    }
-
-    const temp =
-      obj instanceof TypedArray
-        ? new obj.constructor(obj.length)
-        : new obj.constructor();
-
-    map.set(obj, temp);
-
-    if (obj instanceof TypedArray) {
-      temp.set(obj.map((value) => clone(value, map, methodMap)));
-    } else if (obj instanceof Map) {
-      obj.forEach((value, key) => temp.set(key, clone(value, map, methodMap)));
-    } else if (obj instanceof Date) {
-      temp.setTime(obj.getTime());
-    } else {
-      for (const key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          temp[key] = clone(obj[key], map, methodMap);
-        }
+  const defaultCloneProperties = (obj, ref, clone) => {
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        ref[key] = clone(obj[key]);
       }
     }
-    return temp;
+  };
+
+  const defaultMethods = new Map([
+    [Date, [() => new Date(), (date, ref) => ref.setTime(date.getTime())]],
+    [
+      Map,
+      [
+        () => new Map(),
+        (map, ref, clone) =>
+          map.forEach((value, key) => ref.set(clone(key), clone(value))),
+      ],
+    ],
+    // do not clone functions by default
+    [Function, null],
+    // empty array: use default methods
+    [Object, []],
+  ]);
+
+  // do not clone HTML nodes by default
+  if (this.Node) {
+    defaultMethods.set([Node, [(node) => node, (node) => node]]);
+  }
+
+  const getByInstance = (obj, methodMap) => {
+    for (const constructor of methodMap.keys()) {
+      if (obj instanceof constructor) return methodMap.get(constructor);
+    }
+  };
+
+  const getCloneMethod = (obj, methodMap) =>
+    methodMap.has(obj.constructor)
+      ? methodMap.get(obj.constructor)
+      : defaultMethods.has(obj.constructor)
+      ? defaultMethods.get(obj.constructor)
+      : getByInstance(obj, methodMap) || getByInstance(obj, defaultMethods);
+
+  const clone = (obj, map, methodMap) => {
+    if (unclonable.test(Object.prototype.toString.call(obj))) return obj;
+    if (map.has(obj)) return map.get(obj);
+    const cloneMethod = getCloneMethod(obj, methodMap);
+    if (!cloneMethod) return obj;
+    const ref = (cloneMethod[0] || defaultCreateReference)(obj);
+    map.set(obj, ref);
+    (cloneMethod[1] || defaultCloneProperties)(obj, ref, (obj) =>
+      clone(obj, map, methodMap)
+    );
+    return ref;
   };
   Object.clone = (obj, methodMap) =>
     clone(obj, new Map(), methodMap || new Map());

--- a/object-clone.js
+++ b/object-clone.js
@@ -1,9 +1,20 @@
 if (typeof Object.clone !== "function") {
-  const clone = (obj, map) => {
-    if (obj === null || typeof obj !== "object" || obj instanceof WeakMap)
+  const unclonable = /^\[object (?:Undefined|Null|Boolean|Number|String|Symbol|WeakMap)\]$/;
+  const clone = (obj, map, methodMap) => {
+    if (
+      unclonable.test(Object.prototype.toString.call(obj)) ||
+      (typeof obj !== "object" && !methodMap.has(obj.constructor))
+    ) {
       return obj;
+    }
 
     if (map.has(obj)) return map.get(obj);
+
+    if (methodMap.has(obj.constructor)) {
+      return methodMap.get(obj.constructor)(obj, map, (obj) =>
+        clone(obj, map, methodMap)
+      );
+    }
 
     const temp =
       obj instanceof TypedArray
@@ -13,19 +24,20 @@ if (typeof Object.clone !== "function") {
     map.set(obj, temp);
 
     if (obj instanceof TypedArray) {
-      temp.set(obj.map((value) => clone(value, map)));
+      temp.set(obj.map((value) => clone(value, map, methodMap)));
     } else if (obj instanceof Map) {
-      obj.forEach((value, key) => temp.set(key, clone(value, map)));
+      obj.forEach((value, key) => temp.set(key, clone(value, map, methodMap)));
     } else if (obj instanceof Date) {
       temp.setTime(obj.getTime());
     } else {
       for (const key in obj) {
         if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          temp[key] = clone(obj[key], map);
+          temp[key] = clone(obj[key], map, methodMap);
         }
       }
     }
     return temp;
   };
-  Object.clone = (obj) => clone(obj, new Map());
+  Object.clone = (obj, methodMap) =>
+    clone(obj, new Map(), methodMap || new Map());
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "object-clone-proposal",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Proposal for an Object.clone method in ECMAScript",
   "main": "object-clone.js",
   "homepage": "https://github.com/atk/object-clone-proposal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "object-clone-proposal",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Proposal for an Object.clone method in ECMAScript",
   "main": "object-clone.js",
   "homepage": "https://github.com/atk/object-clone-proposal",


### PR DESCRIPTION
Splitting the extension steps of creating a reference and cloning the properties makes the polyfill a little more complex, but also makes the extensions more failsafe and convenient, since it is now impossible to introduce cyclic references by omitting the `map.set` command and also you can use default methods by just omitting the custom ones.